### PR TITLE
Allow relationship's resource identifier objects to have a "meta" value.

### DIFF
--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -77,6 +77,9 @@ class Relationship
                     "id" => $data["id"]
                 ]
             ];
+            if (! empty($data["meta"])) {
+                $resourceMap[0]["meta"] = $data["meta"];
+            }
         }
 
         return new Relationship($name, $meta, $links, $resourceMap, $resources, $isToOneRelationship);
@@ -94,10 +97,14 @@ class Relationship
 
         foreach ($data as $item) {
             if (empty($item["type"]) === false && empty($item["id"]) === false) {
-                $resourceMap[] = [
+                $resource = [
                     "type" => $item["type"],
                     "id" => $item["id"]
                 ];
+                if (! empty($item["meta"])) {
+                    $resource["meta"] = $item["meta"];
+                }
+                $resourceMap[] = $resource;
             }
         }
 
@@ -253,6 +260,25 @@ class Relationship
     public function resourceBy(string $type, string $id)
     {
         return $this->resources->resource($type, $id);
+    }
+
+    /**
+     * Get meta information that may be defined next to the resource identifier link.
+     * This occurs when a relationship contains additional data besides the relation's identifiers.
+     *
+     * @param string $type
+     * @param string $id
+     * @return null|array
+     */
+    public function resourceLinkMeta(string $type, string $id)
+    {
+        foreach ($this->resourceMap as $resourceLink) {
+            if (isset($resourceLink["meta"]) && $resourceLink["type"] === $type && $resourceLink["id"] === $id) {
+                return $resourceLink["meta"];
+            }
+        }
+
+        return null;
     }
 
     private static function isAssociativeArray(array $array): bool


### PR DESCRIPTION
Allow relationship's resource identifier objects to have a "meta" value as well, following JSON API specification: http://jsonapi.org/format/#document-resource-identifier-objects. Additionally add a utility method to retrieve a relation link's meta value.

Considering this valid JSON API response for two "main_resource" resources with each a relationship to the same "secondary_resource" resource, but for each relationship there's also a specific value for the relation between that "main_resource" and "secondary_resource":
```
{
  "data": [
    {
      "type": "main_resource",
      "id": "uuid-main-resource-1",
      "attributes": {
        "name": "Main resource"
      },
      "relationships": {
        "some-property": {
          "data": {
            "type": "secondary_resource",
            "id": "uuid-secondary-resource",
            "meta": {
              "foobar": "Some meta value specific for relation between uuid-main-resource-1 and uuid-secondary-resource.",
              "created": "Relationship created date: 2017-08-11"
            }
          },
          "links": {
            "self": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-1/relationships/some-property",
            "related": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-1/some-property"
          }
        }
      },
      "links": {
        "self": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-1"
      }
    },
    {
      "type": "main_resource",
      "id": "uuid-main-resource-2",
      "attributes": {
        "name": "Main resource"
      },
      "relationships": {
        "some-property": {
          "data": {
            "type": "secondary_resource",
            "id": "uuid-secondary-resource",
            "meta": {
              "foobar": "Some meta value specific for relation between uuid-main-resource-2 and uuid-secondary-resource.",
              "created": "Relationship created date: 2017-08-01"
            }
          },
          "links": {
            "self": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-2/relationships/some-property",
            "related": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-2/some-property"
          }
        }
      },
      "links": {
        "self": "https//foobar.com/jsonapi/main_resource/uuid-main-resource-2"
      }
    }
  ],
  "links": {
    "self": "https//foobar.com/jsonapi/main_resource/uuid-main-resource?include=secondary_resource"
  },
  "included": [
    {
      "type": "secondary_resource",
      "id": "uuid-secondary-resource",
      "attributes": {
        "name": "Secondary resource"
      },
      "links": {
        "self": "https//foobar.com/jsonapi/secondary_resource/uuid-secondary-resource"
      }
    }
  ]
}
```