### PR TITLE
Fix For Unexpected Behaviour When To-One Relationship Data Is NULL - Closes #7

### DIFF
--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -41,7 +41,8 @@ class Relationship
         $links = Links::createFromArray(self::isArrayKey($array, "links") ? $array["links"] : []);
 
         if (self::isArrayKey($array, "data") === false) {
-            return self::createEmptyFromArray($name, $meta, $links, $resources);
+            $isToOneRelationship = array_key_exists("data", $array) && is_null($array["data"]);
+            return self::createEmptyFromArray($name, $meta, $links, $resources, $isToOneRelationship);
         }
 
         if (self::isAssociativeArray($array["data"])) {
@@ -55,9 +56,10 @@ class Relationship
         string $name,
         array $meta,
         Links $links,
-        ResourceObjects $resources
+        ResourceObjects $resources,
+        $isToOneRelationship = null
     ): Relationship {
-        return new Relationship($name, $meta, $links, [], $resources, null);
+        return new Relationship($name, $meta, $links, [], $resources, $isToOneRelationship);
     }
 
     private static function createToOneFromArray(

--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -143,7 +143,7 @@ class Relationship
 
         if (empty($this->resourceMap) === false) {
             $result["data"] = $this->isToOneRelationship ? reset($this->resourceMap) : $this->resourceMap;
-        }else{
+        } else {
             $result["data"] = $this->isToOneRelationship ? null : [];
         }
 

--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -41,7 +41,7 @@ class Relationship
         $links = Links::createFromArray(self::isArrayKey($array, "links") ? $array["links"] : []);
 
         if (self::isArrayKey($array, "data") === false) {
-            $isToOneRelationship = array_key_exists("data", $array) && is_null($array["data"]);
+            $isToOneRelationship = array_key_exists("data", $array) && $array["data"] === null;
             return self::createEmptyFromArray($name, $meta, $links, $resources, $isToOneRelationship);
         }
 

--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -143,6 +143,8 @@ class Relationship
 
         if (empty($this->resourceMap) === false) {
             $result["data"] = $this->isToOneRelationship ? reset($this->resourceMap) : $this->resourceMap;
+        }else{
+            $result["data"] = $this->isToOneRelationship ? null : [];
         }
 
         return $result;


### PR DESCRIPTION
**Please see issue #7 for full information.**

JSONAPI spec states to-one relationships with no associated resource should return `{"data": null}` but Yang does not properly account for this when converting `Relationship` to an array. This pull request fixes Yang returning an empty to-many relationship (`['data' => []]`) instead of an empty to-one relationship (`['data' => null]`).