### PR TITLE
Allow ClassDocumentHydrator::hydrateSingleResource() to return other objects than 'stdClass'

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,9 @@ parameters:
             path: '%currentWorkingDirectory%/src/JsonApi/Hydrator/ClassDocumentHydrator'
         -
             message: '#^Access to an undefined property object::.*$#'
-            path: '%currentWorkingDirectory%/src/JsonApi/Hydrator/ClassDocumentHydrator'
+            paths:
+                - '%currentWorkingDirectory%/src/JsonApi/Hydrator/ClassDocumentHydrator'
+                - '%currentWorkingDirectory%/tests/JsonApi/Hydrator/ClassDocumentHydratorTest'
         -
             message: '#^Variable property access on object\.$#'
             path: '%currentWorkingDirectory%/src/JsonApi/Hydrator/ClassDocumentHydrator'

--- a/src/JsonApi/Hydrator/ClassDocumentHydrator.php
+++ b/src/JsonApi/Hydrator/ClassDocumentHydrator.php
@@ -26,7 +26,7 @@ class ClassDocumentHydrator extends AbstractClassDocumentHydrator
         return parent::hydrateCollection($document);
     }
 
-    public function hydrateSingleResource(Document $document): stdClass
+    public function hydrateSingleResource(Document $document): object
     {
         return parent::hydrateSingleResource($document);
     }

--- a/tests/JsonApi/Hydrator/CustomHydratorTest.php
+++ b/tests/JsonApi/Hydrator/CustomHydratorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WoohooLabs\Yang\Tests\JsonApi\Hydrator;
+
+use PHPUnit\Framework\TestCase;
+use WoohooLabs\Yang\JsonApi\Hydrator\ClassDocumentHydrator;
+use WoohooLabs\Yang\JsonApi\Hydrator\DocumentHydratorInterface;
+use WoohooLabs\Yang\JsonApi\Schema\Document;
+use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+
+class CustomHydratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function hydrateSingleResourceWhenSingleResource(): void
+    {
+        $document = [
+            "data" => [
+                "type" => "a",
+                "id" => "1",
+            ],
+        ];
+
+        $document = Document::fromArray($document);
+        $hydrator = $this->getCustomHydrator();
+        $object = $hydrator->hydrateSingleResource($document);
+
+        $this->assertEquals("a", $object->type);
+        $this->assertEquals("1", $object->id);
+    }
+
+    private function getCustomHydrator(): DocumentHydratorInterface
+    {
+        $hydrator = new class extends ClassDocumentHydrator{
+            protected function createObject(ResourceObject $resource): object
+            {
+                $anonymousClass = new class {
+                    //class is empty on purpose
+                };
+
+                return new $anonymousClass();
+            }
+        };
+
+        return new $hydrator();
+    }
+}


### PR DESCRIPTION
This currently "breaks" the use of own hydrators with an error like:

```
Return value of WoohooLabs\Yang\JsonApi\Hydrator\ClassDocumentHydrator::hydrateSingleResource() must be an instance of stdClass, instance of Project\Domain\Model\MyCustomClass returned
```