### PR TITLE
Expand export ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,12 @@
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 
+CHANGELOG.md export-ignore
 CODE_OF_CONDUCT.md export-ignore
 CONTRIBUTING.md export-ignore
 SUPPORT.md export-ignore
+
+docker-compose.yml export-ignore
 
 Makefile export-ignore
 phpcs.xml export-ignore


### PR DESCRIPTION
Excludes two more files which are not relevant for releases.