### PR TITLE
Fixing hydrator issue when relationship is not included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ CHANGED:
 ADDED:
 
 - [#13](https://github.com/woohoolabs/yang/issues/13): `DocumentHydratorInterface` and `ClassDocumentHydrator` in order to fix some issues with the `HydratorInterface` and `ClassHydrator`
-- [#15](https://github.com/woohoolabs/yang/issues/15): New accessor and mutator methods for `WoohooLabs\Yang\JsonApi\Request\ResourceObject`: `id()`, `setId()`, `type()`, `setType()`,
+- [#15](https://github.com/woohoolabs/yang/issues/15): New accessor and mutator methods for `BahaaAlhagar\Yang\JsonApi\Request\ResourceObject`: `id()`, `setId()`, `type()`, `setType()`,
 `attributes()`, `relationships()`
 
 DEPRECATED:
@@ -90,11 +90,11 @@ CHANGED:
     - `Relationship::resourceBy()` throws an exception instead of returning null if the requested resource is missing
     - `ResourceObject::relationship()` throws an exception instead of returning null if the requested relationship is missing
 - Move errors, links, and resources to their own namespace (__BREAKING CHANGE__):
-    - `WoohooLabs\Yang\JsonApi\Schema\Error` to `WoohooLabs\Yang\JsonApi\Schema\Error\Error`
-    - `WoohooLabs\Yang\JsonApi\Schema\ErrorSource` to `WoohooLabs\Yang\JsonApi\Schema\Error\ErrorSource`
-    - `WoohooLabs\Yang\JsonApi\Schema\Link` to `WoohooLabs\Yang\JsonApi\Schema\Link\Link`
-    - `WoohooLabs\Yang\JsonApi\Schema\ResourceObjects` to `WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects`
-    - `WoohooLabs\Yang\JsonApi\Schema\ResourceObject` to `WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\Error` to `BahaaAlhagar\Yang\JsonApi\Schema\Error\Error`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ErrorSource` to `BahaaAlhagar\Yang\JsonApi\Schema\Error\ErrorSource`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\Link` to `BahaaAlhagar\Yang\JsonApi\Schema\Link\Link`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ResourceObjects` to `BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ResourceObject` to `BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject`
 - Return separate classes instead of a general `Links` for the different types of links (__BREAKING CHANGE__):
     - `DocumentLinks` when using `Document::links()`
     - `ResourceLinks` when using `ResourceObject::links()`
@@ -135,11 +135,11 @@ CHANGED:
     - `Relationship::resourceBy()` throws an exception instead of returning null if the requested resource is missing
     - `ResourceObject::relationship()` throws an exception instead of returning null if the requested relationship is missing
 - Move errors, links, and resources to their own namespace (__BREAKING CHANGE__):
-    - `WoohooLabs\Yang\JsonApi\Schema\Error` to `WoohooLabs\Yang\JsonApi\Schema\Error\Error`
-    - `WoohooLabs\Yang\JsonApi\Schema\ErrorSource` to `WoohooLabs\Yang\JsonApi\Schema\Error\ErrorSource`
-    - `WoohooLabs\Yang\JsonApi\Schema\Link` to `WoohooLabs\Yang\JsonApi\Schema\Link\Link`
-    - `WoohooLabs\Yang\JsonApi\Schema\ResourceObjects` to `WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects`
-    - `WoohooLabs\Yang\JsonApi\Schema\ResourceObject` to `WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\Error` to `BahaaAlhagar\Yang\JsonApi\Schema\Error\Error`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ErrorSource` to `BahaaAlhagar\Yang\JsonApi\Schema\Error\ErrorSource`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\Link` to `BahaaAlhagar\Yang\JsonApi\Schema\Link\Link`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ResourceObjects` to `BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects`
+    - `BahaaAlhagar\Yang\JsonApi\Schema\ResourceObject` to `BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject`
 - Return separate classes instead of a general `Links` for the different types of links (__BREAKING CHANGE__):
     - `DocumentLinks` when using `Document::links()`
     - `ResourceLinks` when using `ResourceObject::links()`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For this purpose, you may use the `JsonApiRequestBuilder` class as it can be see
 
 ```php
 use GuzzleHttp\Psr7\Request;
-use WoohooLabs\Yang\JsonApi\Request\JsonApiRequestBuilder;
+use BahaaAlhagar\Yang\JsonApi\Request\JsonApiRequestBuilder;
 
 // Instantiate an empty PSR-7 request, note that the default HTTP method must be provided
 $request = new Request('GET', '');

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
     },
     "autoload": {
         "psr-4": {
-            "BahaaAlhagar\\Yang\\": "src/"
+            "BahaaAlhagar\\Yang\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "BahaaAlhagar\\Yang\\Tests\\": "tests/",
-            "BahaaAlhagar\\Yang\\Examples\\": "examples/"
+            "BahaaAlhagar\\Yang\\Tests\\": "tests",
+            "BahaaAlhagar\\Yang\\Examples\\": "examples"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "woohoolabs/yang",
+    "name": "bahaaalhagar/yang",
     "description": "Woohoo Labs. Yang",
     "type": "library",
     "keywords": ["Woohoo Labs.", "Yang", "JSON API", "PSR-7", "PSR-18"],
@@ -35,13 +35,13 @@
     },
     "autoload": {
         "psr-4": {
-            "WoohooLabs\\Yang\\": "src/"
+            "BahaaAlhagar\\Yang\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "WoohooLabs\\Yang\\Tests\\": "tests/",
-            "WoohooLabs\\Yang\\Examples\\": "examples/"
+            "BahaaAlhagar\\Yang\\Tests\\": "tests/",
+            "BahaaAlhagar\\Yang\\Examples\\": "examples/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bahaaalhagar/yang",
     "description": "Woohoo Labs. Yang",
-    "type": "library",
+    "type": "package",
     "keywords": ["Woohoo Labs.", "Yang", "JSON API", "PSR-7", "PSR-18"],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "bahaaalhagar/yang",
     "description": "Woohoo Labs. Yang",
-    "type": "package",
     "keywords": ["Woohoo Labs.", "Yang", "JSON API", "PSR-7", "PSR-18"],
     "license": "MIT",
     "authors": [
@@ -10,10 +9,6 @@
             "email": "kocsismate@woohoolabs.com"
         }
     ],
-    "support": {
-        "issues": "https://github.com/woohoolabs/yang/issues",
-        "source": "https://github.com/woohoolabs/yang"
-    },
     "require": {
         "php": "^7.2.0||^8.0.0",
         "php-http/httplug": "^1.0.0|^2.0.0",
@@ -52,5 +47,8 @@
     },
     "config": {
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+
 }

--- a/examples/book.php
+++ b/examples/book.php
@@ -5,8 +5,8 @@ require "../vendor/autoload.php";
 
 use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Guzzle6\Client as GuzzleClient;
-use WoohooLabs\Yang\JsonApi\Client\JsonApiClient;
-use WoohooLabs\Yang\JsonApi\Request\JsonApiRequestBuilder;
+use BahaaAlhagar\Yang\JsonApi\Client\JsonApiClient;
+use BahaaAlhagar\Yang\JsonApi\Request\JsonApiRequestBuilder;
 
 // Create request
 $requestBuilder = new JsonApiRequestBuilder(new Request("GET", ""));

--- a/src/JsonApi/Client/JsonApiAsyncClient.php
+++ b/src/JsonApi/Client/JsonApiAsyncClient.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Client;
+namespace BahaaAlhagar\Yang\JsonApi\Client;
 
-use Http\Client\HttpAsyncClient;
 use Http\Promise\Promise;
+use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\RequestInterface;
 
 class JsonApiAsyncClient

--- a/src/JsonApi/Client/JsonApiClient.php
+++ b/src/JsonApi/Client/JsonApiClient.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Client;
+namespace BahaaAlhagar\Yang\JsonApi\Client;
 
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
-use WoohooLabs\Yang\JsonApi\Response\JsonApiResponse;
-use WoohooLabs\Yang\JsonApi\Serializer\DeserializerInterface;
-use WoohooLabs\Yang\JsonApi\Serializer\JsonDeserializer;
+use BahaaAlhagar\Yang\JsonApi\Response\JsonApiResponse;
+use BahaaAlhagar\Yang\JsonApi\Serializer\JsonDeserializer;
+use BahaaAlhagar\Yang\JsonApi\Serializer\DeserializerInterface;
 
 class JsonApiClient
 {

--- a/src/JsonApi/Exception/DocumentException.php
+++ b/src/JsonApi/Exception/DocumentException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Exception;
+namespace BahaaAlhagar\Yang\JsonApi\Exception;
 
 use Exception;
 

--- a/src/JsonApi/Exception/JsonApiExceptionInterface.php
+++ b/src/JsonApi/Exception/JsonApiExceptionInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Exception;
+namespace BahaaAlhagar\Yang\JsonApi\Exception;
 
 use Throwable;
 

--- a/src/JsonApi/Exception/ResponseException.php
+++ b/src/JsonApi/Exception/ResponseException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Exception;
+namespace BahaaAlhagar\Yang\JsonApi\Exception;
 
 use Exception;
 

--- a/src/JsonApi/Exception/SerializationException.php
+++ b/src/JsonApi/Exception/SerializationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Exception;
+namespace BahaaAlhagar\Yang\JsonApi\Exception;
 
 use Exception;
 

--- a/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
+++ b/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
@@ -8,6 +8,7 @@ use WoohooLabs\Yang\JsonApi\Schema\Document;
 use WoohooLabs\Yang\JsonApi\Schema\Relationship;
 use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
 use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 abstract class AbstractClassDocumentHydrator implements DocumentHydratorInterface
 {

--- a/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
+++ b/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace WoohooLabs\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
 use WoohooLabs\Yang\JsonApi\Schema\Document;
 use WoohooLabs\Yang\JsonApi\Schema\Relationship;
+use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
 use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
 
 abstract class AbstractClassDocumentHydrator implements DocumentHydratorInterface
@@ -118,7 +118,11 @@ abstract class AbstractClassDocumentHydrator implements DocumentHydratorInterfac
                 }
 
                 if ($object === null) {
-                    continue;
+                    if (isset($link["type"], $link["id"])) {
+                        $relatedResource = ResourceObject::fromArray($link, new ResourceObjects([], [], $relationship->isToOneRelationship()));
+
+                        $object = $this->hydrateResource($relatedResource, $document, $resourceMap);
+                    }
                 }
 
                 $result = $this->hydrateResourceRelationship($result, $relationship, $name, $object);

--- a/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
+++ b/src/JsonApi/Hydrator/AbstractClassDocumentHydrator.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Schema\Relationship;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\Relationship;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 abstract class AbstractClassDocumentHydrator implements DocumentHydratorInterface
 {

--- a/src/JsonApi/Hydrator/AttributeHydrator.php
+++ b/src/JsonApi/Hydrator/AttributeHydrator.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
 
 class AttributeHydrator implements AttributeHydratorInterface
 {
     public function hydrateResourceAttributes(object $result, ResourceObject $resource): object
     {
         $result->type = $resource->type();
-        $result->id   = $resource->id();
+        $result->id = $resource->id();
+
         foreach ($resource->attributes() as $attribute => $value) {
             $result->{$attribute} = $value;
         }

--- a/src/JsonApi/Hydrator/AttributeHydratorInterface.php
+++ b/src/JsonApi/Hydrator/AttributeHydratorInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
 
 interface AttributeHydratorInterface
 {

--- a/src/JsonApi/Hydrator/ClassDocumentHydrator.php
+++ b/src/JsonApi/Hydrator/ClassDocumentHydrator.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
 use stdClass;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Schema\Relationship;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\Relationship;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
 
 class ClassDocumentHydrator extends AbstractClassDocumentHydrator
 {

--- a/src/JsonApi/Hydrator/ClassHydrator.php
+++ b/src/JsonApi/Hydrator/ClassHydrator.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
 use stdClass;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
 
 /**
  * @deprecated Use the ClassDocumentHydrator instead.
@@ -86,6 +86,7 @@ final class ClassHydrator implements HydratorInterface
         $result = new stdClass();
         $result->type = $resource->type();
         $result->id = $resource->id();
+
         foreach ($resource->attributes() as $attribute => $value) {
             $result->{$attribute} = $value;
         }

--- a/src/JsonApi/Hydrator/DocumentHydratorInterface.php
+++ b/src/JsonApi/Hydrator/DocumentHydratorInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 interface DocumentHydratorInterface extends HydratorInterface
 {

--- a/src/JsonApi/Hydrator/HydratorInterface.php
+++ b/src/JsonApi/Hydrator/HydratorInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\JsonApi\Hydrator;
 
-use WoohooLabs\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
 
 /**
  * @deprecated Use the DocumentHydratorInterface instead.

--- a/src/JsonApi/Request/JsonApiRequestBuilder.php
+++ b/src/JsonApi/Request/JsonApiRequestBuilder.php
@@ -2,19 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Request;
+namespace BahaaAlhagar\Yang\JsonApi\Request;
 
 use Psr\Http\Message\RequestInterface;
-use WoohooLabs\Yang\JsonApi\Serializer\JsonSerializer;
-use WoohooLabs\Yang\JsonApi\Serializer\SerializerInterface;
-
-use function array_key_exists;
-use function http_build_query;
-use function implode;
-use function is_array;
-use function is_numeric;
-use function parse_str;
-use function parse_url;
+use BahaaAlhagar\Yang\JsonApi\Serializer\JsonSerializer;
+use BahaaAlhagar\Yang\JsonApi\Serializer\SerializerInterface;
 
 class JsonApiRequestBuilder
 {
@@ -127,7 +119,7 @@ class JsonApiRequestBuilder
 
     public function setUri(string $uri): JsonApiRequestBuilder
     {
-        $parsedUri = parse_url($uri);
+        $parsedUri = \parse_url($uri);
 
         if ($parsedUri === false) {
             return $this;
@@ -150,7 +142,7 @@ class JsonApiRequestBuilder
         }
 
         if ($this->isBlankKey($parsedUri, "query") === false) {
-            parse_str($parsedUri["query"], $this->queryString);
+            \parse_str($parsedUri["query"], $this->queryString);
         }
 
         return $this;
@@ -314,14 +306,14 @@ class JsonApiRequestBuilder
 
     private function getQueryString(): string
     {
-        return http_build_query($this->queryString);
+        return \http_build_query($this->queryString);
     }
 
     private function setArrayQueryParam(string $name, array $queryParam): void
     {
         foreach ($queryParam as $key => $value) {
-            if (is_array($value)) {
-                $this->queryString[$name][$key] = implode(",", $value);
+            if (\is_array($value)) {
+                $this->queryString[$name][$key] = \implode(",", $value);
             } else {
                 $this->queryString[$name][$key] = $value;
             }
@@ -333,8 +325,8 @@ class JsonApiRequestBuilder
      */
     private function setListQueryParam(string $name, $queryParam): void
     {
-        if (is_array($queryParam)) {
-            $this->queryString[$name] = implode(",", $queryParam);
+        if (\is_array($queryParam)) {
+            $this->queryString[$name] = \implode(",", $queryParam);
         } else {
             $this->queryString[$name] = $queryParam;
         }
@@ -342,7 +334,7 @@ class JsonApiRequestBuilder
 
     private function isBlankKey(array $array, string $key): bool
     {
-        return array_key_exists($key, $array) === false || (empty($array[$key]) && is_numeric($array[$key]) === false);
+        return \array_key_exists($key, $array) === false || (empty($array[$key]) && \is_numeric($array[$key]) === false);
     }
 
     private function getMediaTypeWithProfiles(array $profiles, bool $compatibility): string
@@ -350,7 +342,7 @@ class JsonApiRequestBuilder
         $result = "application/vnd.api+json";
 
         if (empty($profiles) === false) {
-            $result .= ';profile="' . implode(" ", $profiles) . '"'
+            $result .= ';profile="' . \implode(" ", $profiles) . '"'
                     . ($compatibility ? ',application/vnd.api+json' : "");
         }
 

--- a/src/JsonApi/Request/RelationshipInterface.php
+++ b/src/JsonApi/Request/RelationshipInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Request;
+namespace BahaaAlhagar\Yang\JsonApi\Request;
 
 interface RelationshipInterface
 {

--- a/src/JsonApi/Request/ResourceObject.php
+++ b/src/JsonApi/Request/ResourceObject.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Request;
+namespace BahaaAlhagar\Yang\JsonApi\Request;
 
 class ResourceObject
 {

--- a/src/JsonApi/Request/ToManyRelationship.php
+++ b/src/JsonApi/Request/ToManyRelationship.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Request;
+namespace BahaaAlhagar\Yang\JsonApi\Request;
 
 final class ToManyRelationship implements RelationshipInterface
 {

--- a/src/JsonApi/Request/ToOneRelationship.php
+++ b/src/JsonApi/Request/ToOneRelationship.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Request;
+namespace BahaaAlhagar\Yang\JsonApi\Request;
 
 final class ToOneRelationship implements RelationshipInterface
 {

--- a/src/JsonApi/Response/AbstractResponse.php
+++ b/src/JsonApi/Response/AbstractResponse.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Response;
+namespace BahaaAlhagar\Yang\JsonApi\Response;
 
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\ResponseInterface;
 
 abstract class AbstractResponse implements ResponseInterface
 {

--- a/src/JsonApi/Response/JsonApiResponse.php
+++ b/src/JsonApi/Response/JsonApiResponse.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Response;
+namespace BahaaAlhagar\Yang\JsonApi\Response;
 
 use Psr\Http\Message\ResponseInterface;
-use WoohooLabs\Yang\JsonApi\Exception\ResponseException;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Serializer\DeserializerInterface;
-use WoohooLabs\Yang\JsonApi\Serializer\JsonDeserializer;
-
-use function in_array;
-use function is_array;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Exception\ResponseException;
+use BahaaAlhagar\Yang\JsonApi\Serializer\JsonDeserializer;
+use BahaaAlhagar\Yang\JsonApi\Serializer\DeserializerInterface;
 
 class JsonApiResponse extends AbstractResponse
 {
@@ -58,7 +55,7 @@ class JsonApiResponse extends AbstractResponse
 
     public function isSuccessful(array $successfulStatusCodes = []): bool
     {
-        $isStatusCodeSuccessful = empty($successfulStatusCodes) || in_array($this->getStatusCode(), $successfulStatusCodes, true);
+        $isStatusCodeSuccessful = empty($successfulStatusCodes) || \in_array($this->getStatusCode(), $successfulStatusCodes, true);
 
         $hasNoErrors = $this->hasDocument() === false || $this->document()->hasErrors() === false;
 
@@ -74,7 +71,7 @@ class JsonApiResponse extends AbstractResponse
     {
         $content = $this->deserializer->deserialize($this->response);
 
-        if (is_array($content) === false) {
+        if (\is_array($content) === false) {
             return null;
         }
 

--- a/src/JsonApi/Schema/Document.php
+++ b/src/JsonApi/Schema/Document.php
@@ -2,18 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema;
+namespace BahaaAlhagar\Yang\JsonApi\Schema;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Error\Error;
-use WoohooLabs\Yang\JsonApi\Schema\Link\DocumentLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
-
-use function array_filter;
-use function array_keys;
-use function count;
-use function is_array;
+use BahaaAlhagar\Yang\JsonApi\Schema\Error\Error;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\DocumentLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 final class Document
 {
@@ -152,7 +147,7 @@ final class Document
 
     public function errorCount(): int
     {
-        return count($this->errors);
+        return \count($this->errors);
     }
 
     /**
@@ -172,42 +167,43 @@ final class Document
      */
     public static function fromArray(array $document): Document
     {
-        if (isset($document["jsonapi"]) && is_array($document["jsonapi"])) {
+        if (isset($document["jsonapi"]) && \is_array($document["jsonapi"])) {
             $jsonApi = $document["jsonapi"];
         } else {
             $jsonApi = [];
         }
         $jsonApiObject = JsonApiObject::fromArray($jsonApi);
 
-        if (isset($document["meta"]) && is_array($document["meta"])) {
+        if (isset($document["meta"]) && \is_array($document["meta"])) {
             $meta = $document["meta"];
         } else {
             $meta = [];
         }
 
-        if (isset($document["links"]) && is_array($document["links"])) {
+        if (isset($document["links"]) && \is_array($document["links"])) {
             $links = $document["links"];
         } else {
             $links = [];
         }
         $linksObject = DocumentLinks::fromArray($links);
 
-        if (isset($document["included"]) && is_array($document["included"])) {
+        if (isset($document["included"]) && \is_array($document["included"])) {
             $included = $document["included"];
         } else {
             $included = [];
         }
 
-        if (isset($document["data"]) && is_array($document["data"])) {
+        if (isset($document["data"]) && \is_array($document["data"])) {
             $resources = new ResourceObjects($document["data"], $included, self::isAssociativeArray($document["data"]));
         } else {
             $resources = ResourceObjects::fromSinglePrimaryData([], $included);
         }
 
         $errors = [];
-        if (isset($document["errors"]) && is_array($document["errors"])) {
+
+        if (isset($document["errors"]) && \is_array($document["errors"])) {
             foreach ($document["errors"] as $error) {
-                if (is_array($error)) {
+                if (\is_array($error)) {
                     $errors[] = Error::fromArray($error);
                 }
             }
@@ -236,6 +232,7 @@ final class Document
 
         if ($this->hasErrors()) {
             $errors = [];
+
             foreach ($this->errors as $error) {
                 $errors[] = $error->toArray();
             }
@@ -251,6 +248,6 @@ final class Document
 
     private static function isAssociativeArray(array $array): bool
     {
-        return (bool) count(array_filter(array_keys($array), "is_string"));
+        return (bool) \count(\array_filter(\array_keys($array), "is_string"));
     }
 }

--- a/src/JsonApi/Schema/Error/Error.php
+++ b/src/JsonApi/Schema/Error/Error.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Error;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Error;
 
-use WoohooLabs\Yang\JsonApi\Schema\Link\ErrorLinks;
-
-use function is_array;
-use function is_scalar;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ErrorLinks;
 
 final class Error
 {
@@ -132,14 +128,14 @@ final class Error
      */
     public static function fromArray(array $error): Error
     {
-        $id = isset($error["id"]) && is_string($error["id"]) ? $error["id"] : "";
-        $meta = isset($error["meta"]) && is_array($error["meta"]) ? $error["meta"] : [];
-        $links = ErrorLinks::fromArray(isset($error["links"]) && is_array($error["links"]) ? $error["links"] : []);
-        $status = isset($error["status"]) && is_scalar($error["status"]) ? (string) $error["status"] : "";
-        $code = isset($error["code"]) && is_string($error["code"]) ? $error["code"] : "";
-        $title = isset($error["title"]) && is_string($error["title"]) ? $error["title"] : "";
-        $detail = isset($error["detail"]) && is_string($error["detail"]) ? $error["detail"] : "";
-        $source = ErrorSource::fromArray(isset($error["source"]) && is_array($error["source"]) ? $error["source"] : []);
+        $id = isset($error["id"]) && \is_string($error["id"]) ? $error["id"] : "";
+        $meta = isset($error["meta"]) && \is_array($error["meta"]) ? $error["meta"] : [];
+        $links = ErrorLinks::fromArray(isset($error["links"]) && \is_array($error["links"]) ? $error["links"] : []);
+        $status = isset($error["status"]) && \is_scalar($error["status"]) ? (string) $error["status"] : "";
+        $code = isset($error["code"]) && \is_string($error["code"]) ? $error["code"] : "";
+        $title = isset($error["title"]) && \is_string($error["title"]) ? $error["title"] : "";
+        $detail = isset($error["detail"]) && \is_string($error["detail"]) ? $error["detail"] : "";
+        $source = ErrorSource::fromArray(isset($error["source"]) && \is_array($error["source"]) ? $error["source"] : []);
 
         return new self($id, $meta, $links, $status, $code, $title, $detail, $source);
     }

--- a/src/JsonApi/Schema/Error/ErrorSource.php
+++ b/src/JsonApi/Schema/Error/ErrorSource.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Error;
-
-use function is_string;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Error;
 
 final class ErrorSource
 {
@@ -54,8 +52,8 @@ final class ErrorSource
      */
     public static function fromArray(array $source): ErrorSource
     {
-        $pointer = isset($source["pointer"]) && is_string($source["pointer"]) ? $source["pointer"] : "";
-        $parameter = isset($source["parameter"]) && is_string($source["parameter"]) ? $source["parameter"] : "";
+        $pointer = isset($source["pointer"]) && \is_string($source["pointer"]) ? $source["pointer"] : "";
+        $parameter = isset($source["parameter"]) && \is_string($source["parameter"]) ? $source["parameter"] : "";
 
         return new self($pointer, $parameter);
     }

--- a/src/JsonApi/Schema/JsonApiObject.php
+++ b/src/JsonApi/Schema/JsonApiObject.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema;
-
-use function is_array;
-use function is_string;
+namespace BahaaAlhagar\Yang\JsonApi\Schema;
 
 final class JsonApiObject
 {
@@ -45,8 +42,8 @@ final class JsonApiObject
      */
     public static function fromArray(array $array): JsonApiObject
     {
-        $version = isset($array["version"]) && is_string($array["version"]) && $array["version"] !== "" ? $array["version"] : "1.0";
-        $meta = isset($array["meta"]) && is_array($array["meta"]) ? $array["meta"] : [];
+        $version = isset($array["version"]) && \is_string($array["version"]) && $array["version"] !== "" ? $array["version"] : "1.0";
+        $meta = isset($array["meta"]) && \is_array($array["meta"]) ? $array["meta"] : [];
 
         return new self($version, $meta);
     }

--- a/src/JsonApi/Schema/Link/AbstractLink.php
+++ b/src/JsonApi/Schema/Link/AbstractLink.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
 abstract class AbstractLink
 {

--- a/src/JsonApi/Schema/Link/AbstractLinks.php
+++ b/src/JsonApi/Schema/Link/AbstractLinks.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 abstract class AbstractLinks
 {

--- a/src/JsonApi/Schema/Link/DocumentLinks.php
+++ b/src/JsonApi/Schema/Link/DocumentLinks.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-
-use function array_values;
-use function is_array;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class DocumentLinks extends AbstractLinks
 {
@@ -115,7 +111,7 @@ final class DocumentLinks extends AbstractLinks
      */
     public function profiles(): array
     {
-        return array_values($this->profiles);
+        return \array_values($this->profiles);
     }
 
     public function hasProfile(string $href): bool
@@ -145,17 +141,20 @@ final class DocumentLinks extends AbstractLinks
 
         foreach ($links as $name => $link) {
             if ($name === "profile") {
-                $profiles = is_array($link) ? self::createProfiles($link) : [];
+                $profiles = \is_array($link) ? self::createProfiles($link) : [];
+
                 continue;
             }
 
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $linkObjects[$name] = Link::fromString($link);
+
                 continue;
             }
 
-            if (is_array($link)) {
+            if (\is_array($link)) {
                 $linkObjects[$name] = Link::fromArray($link);
+
                 continue;
             }
         }
@@ -182,14 +181,16 @@ final class DocumentLinks extends AbstractLinks
         $profileLinks = [];
 
         foreach ($profiles as $link) {
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $profileLinks[$link] = ProfileLink::fromString($link);
+
                 continue;
             }
 
-            if (is_array($link)) {
+            if (\is_array($link)) {
                 $profileLink = ProfileLink::fromArray($link);
                 $profileLinks[$profileLink->href()] = $profileLink;
+
                 continue;
             }
         }

--- a/src/JsonApi/Schema/Link/ErrorLinks.php
+++ b/src/JsonApi/Schema/Link/ErrorLinks.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-
-use function array_values;
-use function is_array;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class ErrorLinks extends AbstractLinks
 {
@@ -55,7 +51,7 @@ final class ErrorLinks extends AbstractLinks
      */
     public function types(): array
     {
-        return array_values($this->types);
+        return \array_values($this->types);
     }
 
     /**
@@ -80,17 +76,20 @@ final class ErrorLinks extends AbstractLinks
 
         foreach ($links as $name => $link) {
             if ($name === "type") {
-                $types = is_array($link) ? self::createTypes($link) : [];
+                $types = \is_array($link) ? self::createTypes($link) : [];
+
                 continue;
             }
 
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $linkObjects[$name] = Link::fromString($link);
+
                 continue;
             }
 
-            if (is_array($link)) {
+            if (\is_array($link)) {
                 $linkObjects[$name] = Link::fromArray($link);
+
                 continue;
             }
         }
@@ -114,14 +113,16 @@ final class ErrorLinks extends AbstractLinks
         $typeLinks = [];
 
         foreach ($types as $link) {
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $typeLinks[$link] = Link::fromString($link);
+
                 continue;
             }
 
-            if (is_array($link)) {
+            if (\is_array($link)) {
                 $profileLink = Link::fromArray($link);
                 $typeLinks[$profileLink->href()] = $profileLink;
+
                 continue;
             }
         }

--- a/src/JsonApi/Schema/Link/Link.php
+++ b/src/JsonApi/Schema/Link/Link.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
-
-use function is_array;
-use function is_string;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
 final class Link extends AbstractLink
 {
@@ -22,8 +19,8 @@ final class Link extends AbstractLink
      */
     public static function fromArray(array $link): Link
     {
-        $href = isset($link["href"]) && is_string($link["href"]) ? $link["href"] : "";
-        $meta = isset($link["meta"]) && is_array($link["meta"]) ? $link["meta"] : [];
+        $href = isset($link["href"]) && \is_string($link["href"]) ? $link["href"] : "";
+        $meta = isset($link["meta"]) && \is_array($link["meta"]) ? $link["meta"] : [];
 
         return new Link($href, $meta);
     }

--- a/src/JsonApi/Schema/Link/ProfileLink.php
+++ b/src/JsonApi/Schema/Link/ProfileLink.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
-
-use function is_array;
-use function is_string;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
 final class ProfileLink extends AbstractLink
 {
@@ -38,9 +35,9 @@ final class ProfileLink extends AbstractLink
      */
     public static function fromArray(array $link): ProfileLink
     {
-        $href = isset($link["href"]) && is_string($link["href"]) ? $link["href"] : "";
-        $meta = isset($link["meta"]) && is_array($link["meta"]) ? $link["meta"] : [];
-        $aliases = isset($link["aliases"]) && is_array($link["aliases"]) ? $link["aliases"] : [];
+        $href = isset($link["href"]) && \is_string($link["href"]) ? $link["href"] : "";
+        $meta = isset($link["meta"]) && \is_array($link["meta"]) ? $link["meta"] : [];
+        $aliases = isset($link["aliases"]) && \is_array($link["aliases"]) ? $link["aliases"] : [];
 
         return new ProfileLink($href, $meta, $aliases);
     }

--- a/src/JsonApi/Schema/Link/RelationshipLinks.php
+++ b/src/JsonApi/Schema/Link/RelationshipLinks.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-
-use function is_array;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class RelationshipLinks extends AbstractLinks
 {
@@ -40,10 +37,11 @@ final class RelationshipLinks extends AbstractLinks
     public static function fromArray(array $links): RelationshipLinks
     {
         $linkObjects = [];
+
         foreach ($links as $name => $link) {
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $linkObjects[$name] = Link::fromString($link);
-            } elseif (is_array($link)) {
+            } elseif (\is_array($link)) {
                 $linkObjects[$name] = Link::fromArray($link);
             }
         }

--- a/src/JsonApi/Schema/Link/ResourceLinks.php
+++ b/src/JsonApi/Schema/Link/ResourceLinks.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Link;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-
-use function is_array;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class ResourceLinks extends AbstractLinks
 {
@@ -27,10 +24,11 @@ final class ResourceLinks extends AbstractLinks
     public static function fromArray(array $links): ResourceLinks
     {
         $linkObjects = [];
+
         foreach ($links as $name => $link) {
-            if (is_string($link)) {
+            if (\is_string($link)) {
                 $linkObjects[$name] = Link::fromString($link);
-            } elseif (is_array($link)) {
+            } elseif (\is_array($link)) {
                 $linkObjects[$name] = Link::fromArray($link);
             }
         }

--- a/src/JsonApi/Schema/Relationship.php
+++ b/src/JsonApi/Schema/Relationship.php
@@ -2,20 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema;
+namespace BahaaAlhagar\Yang\JsonApi\Schema;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\RelationshipLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
-
-use function array_filter;
-use function array_key_exists;
-use function array_keys;
-use function count;
-use function is_array;
-use function is_numeric;
-use function reset;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\RelationshipLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 final class Relationship
 {
@@ -107,7 +99,7 @@ final class Relationship
 
     public function firstResourceLink(): ?array
     {
-        $link = reset($this->resourceMap);
+        $link = \reset($this->resourceMap);
 
         return $link === false ? null : $link;
     }
@@ -131,6 +123,7 @@ final class Relationship
         }
 
         $resources = [];
+
         foreach ($this->resourceMap as $resourceLink) {
             if ($this->hasIncludedResource($resourceLink["type"], $resourceLink["id"])) {
                 $resources[] = $this->resourceBy($resourceLink["type"], $resourceLink["id"]);
@@ -146,9 +139,11 @@ final class Relationship
     public function resourceMap(): array
     {
         $resources = [];
+
         foreach ($this->resourceMap as $resourceLink) {
             $type = $resourceLink["type"];
             $id = $resourceLink["id"];
+
             if ($this->hasIncludedResource($type, $id)) {
                 $resources[$type][$id] = $this->resourceBy($type, $id);
             }
@@ -169,7 +164,8 @@ final class Relationship
             );
         }
 
-        $resource = reset($this->resourceMap);
+        $resource = \reset($this->resourceMap);
+
         if ($resource === false) {
             throw new DocumentException("The relationship with '$this->name' name is empty, therefore it doesn't have a single resource.");
         }
@@ -209,7 +205,7 @@ final class Relationship
         $links = RelationshipLinks::fromArray(self::isArrayKey($array, "links") ? $array["links"] : []);
 
         // Data member is missing
-        if (array_key_exists("data", $array) === false) {
+        if (\array_key_exists("data", $array) === false) {
             return self::createEmptyFromArray($name, $meta, $links, $resources, null);
         }
 
@@ -246,7 +242,7 @@ final class Relationship
         if (empty($this->resourceMap)) {
             $result["data"] = $this->isToOneRelationship ? null : [];
         } else {
-            $result["data"] = $this->isToOneRelationship ? reset($this->resourceMap) : $this->resourceMap;
+            $result["data"] = $this->isToOneRelationship ? \reset($this->resourceMap) : $this->resourceMap;
         }
 
         return $result;
@@ -279,6 +275,7 @@ final class Relationship
                     "id" => $data["id"],
                 ],
             ];
+
             if (empty($data["meta"]) === false) {
                 $resourceMap[0]["meta"] = $data["meta"];
             }
@@ -303,6 +300,7 @@ final class Relationship
                     "type" => $item["type"],
                     "id" => $item["id"],
                 ];
+
                 if (empty($item["meta"]) === false) {
                     $resource["meta"] = $item["meta"];
                 }
@@ -315,16 +313,16 @@ final class Relationship
 
     private static function isAssociativeArray(array $array): bool
     {
-        return (bool) count(array_filter(array_keys($array), "is_string"));
+        return (bool) \count(\array_filter(\array_keys($array), "is_string"));
     }
 
     private static function isArrayKey(array $array, string $key): bool
     {
-        return isset($array[$key]) && is_array($array[$key]);
+        return isset($array[$key]) && \is_array($array[$key]);
     }
 
     private static function isBlankKey(array $array, string $key): bool
     {
-        return array_key_exists($key, $array) === false || (empty($array[$key]) && is_numeric($array[$key]) === false);
+        return \array_key_exists($key, $array) === false || (empty($array[$key]) && \is_numeric($array[$key]) === false);
     }
 }

--- a/src/JsonApi/Schema/Resource/ResourceObject.php
+++ b/src/JsonApi/Schema/Resource/ResourceObject.php
@@ -2,16 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Resource;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Resource;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ResourceLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Relationship;
-
-use function array_key_exists;
-use function array_merge;
-use function is_array;
-use function is_string;
+use BahaaAlhagar\Yang\JsonApi\Schema\Relationship;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ResourceLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class ResourceObject
 {
@@ -101,12 +96,12 @@ final class ResourceObject
 
     public function idAndAttributes(): array
     {
-        return array_merge(["id" => $this->id()], $this->attributes());
+        return \array_merge(["id" => $this->id()], $this->attributes());
     }
 
     public function hasAttribute(string $name): bool
     {
-        return array_key_exists($name, $this->attributes);
+        return \array_key_exists($name, $this->attributes);
     }
 
     /**
@@ -128,7 +123,7 @@ final class ResourceObject
 
     public function hasRelationship(string $name): bool
     {
-        return array_key_exists($name, $this->relationships);
+        return \array_key_exists($name, $this->relationships);
     }
 
     /**
@@ -148,16 +143,17 @@ final class ResourceObject
      */
     public static function fromArray(array $array, ResourceObjects $resources): ResourceObject
     {
-        $type = isset($array["type"]) && is_string($array["type"]) ? $array["type"] : "";
-        $id = isset($array["id"]) && is_string($array["id"]) ? $array["id"] : "";
+        $type = isset($array["type"]) && \is_string($array["type"]) ? $array["type"] : "";
+        $id = isset($array["id"]) && \is_string($array["id"]) ? $array["id"] : "";
         $meta = self::isArrayKey($array, "meta") ? $array["meta"] : [];
         $links = ResourceLinks::fromArray(self::isArrayKey($array, "links") ? $array["links"] : []);
         $attributes = self::isArrayKey($array, "attributes") ? $array["attributes"] : [];
 
         $relationships = [];
+
         if (self::isArrayKey($array, "relationships")) {
             foreach ($array["relationships"] as $name => $relationship) {
-                if (is_string($name) === false || is_array($relationship) === false) {
+                if (\is_string($name) === false || \is_array($relationship) === false) {
                     continue;
                 }
 
@@ -189,6 +185,7 @@ final class ResourceObject
 
         if (empty($this->relationships) === false) {
             $result["relationships"] = [];
+
             foreach ($this->relationships as $name => $relationship) {
                 $result["relationships"][$name] = $relationship->toArray();
             }
@@ -199,6 +196,6 @@ final class ResourceObject
 
     private static function isArrayKey(array $array, string $key): bool
     {
-        return isset($array[$key]) && is_array($array[$key]);
+        return isset($array[$key]) && \is_array($array[$key]);
     }
 }

--- a/src/JsonApi/Schema/Resource/ResourceObjects.php
+++ b/src/JsonApi/Schema/Resource/ResourceObjects.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Schema\Resource;
+namespace BahaaAlhagar\Yang\JsonApi\Schema\Resource;
 
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-
-use function array_values;
-use function key;
-use function reset;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 final class ResourceObjects
 {
@@ -100,7 +96,7 @@ final class ResourceObjects
             );
         }
 
-        return array_values($this->primaryKeys);
+        return \array_values($this->primaryKeys);
     }
 
     /**
@@ -119,8 +115,8 @@ final class ResourceObjects
             throw new DocumentException("The document doesn't contain any primary resources!");
         }
 
-        reset($this->primaryKeys);
-        $key = key($this->primaryKeys);
+        \reset($this->primaryKeys);
+        $key = \key($this->primaryKeys);
 
         return $this->resources[$key];
     }
@@ -140,7 +136,7 @@ final class ResourceObjects
      */
     public function includedResources(): array
     {
-        return array_values($this->includedKeys);
+        return \array_values($this->includedKeys);
     }
 
     /**
@@ -167,6 +163,7 @@ final class ResourceObjects
     public function includedToArray(): array
     {
         $result = [];
+
         foreach ($this->includedKeys as $resource) {
             $result[] = $resource->toArray();
         }
@@ -180,8 +177,8 @@ final class ResourceObjects
             return null;
         }
 
-        reset($this->primaryKeys);
-        $key = key($this->primaryKeys);
+        \reset($this->primaryKeys);
+        $key = \key($this->primaryKeys);
 
         return $this->resources[$key]->toArray();
     }
@@ -189,6 +186,7 @@ final class ResourceObjects
     private function primaryCollectionToArray(): array
     {
         $result = [];
+
         foreach ($this->primaryKeys as $resource) {
             $result[] = $resource->toArray();
         }

--- a/src/JsonApi/Serializer/DeserializerInterface.php
+++ b/src/JsonApi/Serializer/DeserializerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\JsonApi\Serializer;
 
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/JsonApi/Serializer/JsonDeserializer.php
+++ b/src/JsonApi/Serializer/JsonDeserializer.php
@@ -2,11 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\JsonApi\Serializer;
 
 use Psr\Http\Message\ResponseInterface;
-
-use function json_decode;
 
 final class JsonDeserializer implements DeserializerInterface
 {
@@ -31,6 +29,6 @@ final class JsonDeserializer implements DeserializerInterface
      */
     public function deserialize(ResponseInterface $response)
     {
-        return json_decode($response->getBody()->__toString(), true, $this->depth, $this->options);
+        return \json_decode($response->getBody()->__toString(), true, $this->depth, $this->options);
     }
 }

--- a/src/JsonApi/Serializer/JsonSerializer.php
+++ b/src/JsonApi/Serializer/JsonSerializer.php
@@ -2,14 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\JsonApi\Serializer;
 
 use Psr\Http\Message\RequestInterface;
-use WoohooLabs\Yang\JsonApi\Exception\SerializationException;
-
-use function is_array;
-use function is_string;
-use function json_encode;
+use BahaaAlhagar\Yang\JsonApi\Exception\SerializationException;
 
 final class JsonSerializer implements SerializerInterface
 {
@@ -35,9 +31,9 @@ final class JsonSerializer implements SerializerInterface
      */
     public function serialize(RequestInterface $request, $body): RequestInterface
     {
-        if (is_array($body)) {
-            $body = json_encode($body, $this->options, $this->depth);
-        } elseif ($body !== null && is_string($body) === false) {
+        if (\is_array($body)) {
+            $body = \json_encode($body, $this->options, $this->depth);
+        } elseif ($body !== null && \is_string($body) === false) {
             throw new SerializationException("The request body can only be provided as a string, an array or null!");
         }
 

--- a/src/JsonApi/Serializer/SerializerInterface.php
+++ b/src/JsonApi/Serializer/SerializerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\JsonApi\Serializer;
 
 use Psr\Http\Message\RequestInterface;
 

--- a/tests/JsonApi/Hydrator/ClassDocumentHydratorTest.php
+++ b/tests/JsonApi/Hydrator/ClassDocumentHydratorTest.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Hydrator;
 
-use PHPUnit\Framework\TestCase;
 use stdClass;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Hydrator\ClassDocumentHydrator;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-
-use function end;
-use function reset;
+use PHPUnit\Framework\TestCase;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Hydrator\ClassDocumentHydrator;
 
 class ClassDocumentHydratorTest extends TestCase
 {
@@ -46,7 +43,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
 
@@ -72,7 +69,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
 
@@ -112,8 +109,8 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object1 = reset($objects) ?: new stdClass();
-        $object2 = end($objects) ?: new stdClass();
+        $object1 = \reset($objects) ?: new stdClass();
+        $object2 = \end($objects) ?: new stdClass();
 
         $this->assertCount(2, $objects);
 
@@ -149,7 +146,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
         $this->assertObjectNotHasAttribute("x", $object);
@@ -188,7 +185,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
         $this->assertObjectHasAttribute("x", $object);
@@ -248,7 +245,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
         $this->assertCount(2, $object->x);
@@ -309,7 +306,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
 
@@ -375,7 +372,7 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $objects = (array) $hydrator->hydrate($document);
-        $object = reset($objects) ?: new stdClass();
+        $object = \reset($objects) ?: new stdClass();
 
         $this->assertCount(1, $objects);
 
@@ -529,8 +526,8 @@ class ClassDocumentHydratorTest extends TestCase
         $document = Document::fromArray($document);
         $hydrator = new ClassDocumentHydrator();
         $collection = (array) $hydrator->hydrateCollection($document);
-        $object1 = reset($collection) ?: new stdClass();
-        $object2 = end($collection) ?: new stdClass();
+        $object1 = \reset($collection) ?: new stdClass();
+        $object2 = \end($collection) ?: new stdClass();
 
         $this->assertCount(2, $collection);
         $this->assertSame("a", $object1->type);

--- a/tests/JsonApi/Hydrator/ClassHydratorTest.php
+++ b/tests/JsonApi/Hydrator/ClassHydratorTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Hydrator;
 
-use PHPUnit\Framework\TestCase;
 use stdClass;
-use WoohooLabs\Yang\JsonApi\Hydrator\ClassHydrator;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
+use PHPUnit\Framework\TestCase;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Hydrator\ClassHydrator;
 
 class ClassHydratorTest extends TestCase
 {

--- a/tests/JsonApi/Hydrator/CustomHydratorTest.php
+++ b/tests/JsonApi/Hydrator/CustomHydratorTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Hydrator;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Hydrator;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Hydrator\ClassDocumentHydrator;
-use WoohooLabs\Yang\JsonApi\Hydrator\DocumentHydratorInterface;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Hydrator\ClassDocumentHydrator;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Hydrator\DocumentHydratorInterface;
 
 class CustomHydratorTest extends TestCase
 {
@@ -34,7 +34,7 @@ class CustomHydratorTest extends TestCase
 
     private function getCustomHydrator(): DocumentHydratorInterface
     {
-        $hydrator = new class extends ClassDocumentHydrator{
+        $hydrator = new class extends ClassDocumentHydrator {
             protected function createObject(ResourceObject $resource): object
             {
                 $anonymousClass = new class {

--- a/tests/JsonApi/Request/JsonApiRequestBuilderTest.php
+++ b/tests/JsonApi/Request/JsonApiRequestBuilderTest.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Request;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Request;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Request\JsonApiRequestBuilder;
-use WoohooLabs\Yang\JsonApi\Request\ResourceObject;
-
-use function urldecode;
+use BahaaAlhagar\Yang\JsonApi\Request\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Request\JsonApiRequestBuilder;
 
 class JsonApiRequestBuilderTest extends TestCase
 {
@@ -226,7 +224,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiFields(["a" => ["b", "c"]]);
 
-        $this->assertSame("fields[a]=b,c", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("fields[a]=b,c", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -238,7 +236,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiSort(["b", "-c"]);
 
-        $this->assertSame("sort=b,-c", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("sort=b,-c", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -250,7 +248,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiPage(["a" => 1, "b" => 100]);
 
-        $this->assertSame("page[a]=1&page[b]=100", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("page[a]=1&page[b]=100", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -262,7 +260,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiFilter(["a" => "abc"]);
 
-        $this->assertSame("filter[a]=abc", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("filter[a]=abc", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -276,7 +274,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $this->assertSame(
             "filter[a]=abc,xyz",
-            urldecode($requestBuilder->getRequest()->getUri()->getQuery())
+            \urldecode($requestBuilder->getRequest()->getUri()->getQuery())
         );
     }
 
@@ -291,7 +289,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $this->assertSame(
             "filter[a][0]=abc&filter[a][1]=xyz",
-            urldecode($requestBuilder->getRequest()->getUri()->getQuery())
+            \urldecode($requestBuilder->getRequest()->getUri()->getQuery())
         );
     }
 
@@ -314,7 +312,7 @@ class JsonApiRequestBuilderTest extends TestCase
         $this->assertSame(
             "filter[a]=123&filter[b][lt]=50&filter[b][gt]=5&filter[or][c][like]=foo"
             . "&filter[or][c][eq]=bar&filter[d][in][0]=3&filter[d][in][1]=4",
-            urldecode($requestBuilder->getRequest()->getUri()->getQuery())
+            \urldecode($requestBuilder->getRequest()->getUri()->getQuery())
         );
     }
 
@@ -327,7 +325,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiIncludes(["a", "b.c"]);
 
-        $this->assertSame("include=a,b.c", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("include=a,b.c", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -339,7 +337,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $requestBuilder->setJsonApiIncludes("a,b.c");
 
-        $this->assertSame("include=a,b.c", urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
+        $this->assertSame("include=a,b.c", \urldecode($requestBuilder->getRequest()->getUri()->getQuery()));
     }
 
     /**
@@ -389,7 +387,7 @@ class JsonApiRequestBuilderTest extends TestCase
 
         $this->assertSame(
             'profile=abc def',
-            urldecode($requestBuilder->getRequest()->getUri()->getQuery())
+            \urldecode($requestBuilder->getRequest()->getUri()->getQuery())
         );
     }
 

--- a/tests/JsonApi/Request/ResourceObjectTest.php
+++ b/tests/JsonApi/Request/ResourceObjectTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Request;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Request;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Request\ResourceObject;
-use WoohooLabs\Yang\JsonApi\Request\ToManyRelationship;
-use WoohooLabs\Yang\JsonApi\Request\ToOneRelationship;
+use BahaaAlhagar\Yang\JsonApi\Request\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Request\ToOneRelationship;
+use BahaaAlhagar\Yang\JsonApi\Request\ToManyRelationship;
 
 class ResourceObjectTest extends TestCase
 {

--- a/tests/JsonApi/Request/ToManyRelationshipTest.php
+++ b/tests/JsonApi/Request/ToManyRelationshipTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Request;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Request;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Request\ToManyRelationship;
+use BahaaAlhagar\Yang\JsonApi\Request\ToManyRelationship;
 
 class ToManyRelationshipTest extends TestCase
 {

--- a/tests/JsonApi/Request/ToOneRelationshipTest.php
+++ b/tests/JsonApi/Request/ToOneRelationshipTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Request;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Request;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Request\ToOneRelationship;
+use BahaaAlhagar\Yang\JsonApi\Request\ToOneRelationship;
 
 class ToOneRelationshipTest extends TestCase
 {

--- a/tests/JsonApi/Response/AbstractResponseTest.php
+++ b/tests/JsonApi/Response/AbstractResponseTest.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Response;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Response;
 
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Response\JsonApiResponse;
-
-use function json_encode;
+use BahaaAlhagar\Yang\JsonApi\Response\JsonApiResponse;
 
 class AbstractResponseTest extends TestCase
 {
@@ -169,7 +167,7 @@ class AbstractResponseTest extends TestCase
 
     private function createResponse(int $statusCode = 200, array $headers = [], ?array $body = null): JsonApiResponse
     {
-        $data = json_encode($body) ?: null;
+        $data = \json_encode($body) ?: null;
 
         return new JsonApiResponse(new Response($statusCode, $headers, $data));
     }

--- a/tests/JsonApi/Response/JsonApiResponseTest.php
+++ b/tests/JsonApi/Response/JsonApiResponseTest.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Response;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Response;
 
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\ResponseException;
-use WoohooLabs\Yang\JsonApi\Response\JsonApiResponse;
-
-use function json_encode;
+use BahaaAlhagar\Yang\JsonApi\Response\JsonApiResponse;
+use BahaaAlhagar\Yang\JsonApi\Exception\ResponseException;
 
 class JsonApiResponseTest extends TestCase
 {
@@ -167,7 +165,7 @@ class JsonApiResponseTest extends TestCase
 
     private function createResponse(int $statusCode = 200, array $headers = [], ?array $body = null): JsonApiResponse
     {
-        $data = json_encode($body) ?: null;
+        $data = \json_encode($body) ?: null;
 
         return new JsonApiResponse(new Response($statusCode, $headers, $data));
     }

--- a/tests/JsonApi/Schema/DocumentTest.php
+++ b/tests/JsonApi/Schema/DocumentTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Document;
-use WoohooLabs\Yang\JsonApi\Schema\JsonApiObject;
-use WoohooLabs\Yang\JsonApi\Schema\Link\DocumentLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Document;
+use BahaaAlhagar\Yang\JsonApi\Schema\JsonApiObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\DocumentLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 class DocumentTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Error/ErrorSourceTest.php
+++ b/tests/JsonApi/Schema/Error/ErrorSourceTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Error;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Error;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Schema\Error\ErrorSource;
+use BahaaAlhagar\Yang\JsonApi\Schema\Error\ErrorSource;
 
 class ErrorSourceTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Error/ErrorTest.php
+++ b/tests/JsonApi/Schema/Error/ErrorTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Error;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Error;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Schema\Error\Error;
-use WoohooLabs\Yang\JsonApi\Schema\Error\ErrorSource;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ErrorLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Error\Error;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ErrorLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Error\ErrorSource;
 
 class ErrorTest extends TestCase
 {

--- a/tests/JsonApi/Schema/JsonApiObjectTest.php
+++ b/tests/JsonApi/Schema/JsonApiObjectTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Schema\JsonApiObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\JsonApiObject;
 
 class JsonApiObjectTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/AbstractLinksTest.php
+++ b/tests/JsonApi/Schema/Link/AbstractLinksTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\DocumentLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\DocumentLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 class AbstractLinksTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/DocumentLinksTest.php
+++ b/tests/JsonApi/Schema/Link/DocumentLinksTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\DocumentLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ProfileLink;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ProfileLink;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\DocumentLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 class DocumentLinksTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/ErrorLinksTest.php
+++ b/tests/JsonApi/Schema/Link/ErrorLinksTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ErrorLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ErrorLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 class ErrorLinksTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/LinkTest.php
+++ b/tests/JsonApi/Schema/Link/LinkTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
 
 class LinkTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/ProfileLinkTest.php
+++ b/tests/JsonApi/Schema/Link/ProfileLinkTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ProfileLink;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ProfileLink;
 
 class ProfileLinkTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/RelationshipLinksTest.php
+++ b/tests/JsonApi/Schema/Link/RelationshipLinksTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
-use WoohooLabs\Yang\JsonApi\Schema\Link\RelationshipLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\RelationshipLinks;
 
 class RelationshipLinksTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Link/ResourceLinksTest.php
+++ b/tests/JsonApi/Schema/Link/ResourceLinksTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Link;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Link;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\Link;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ResourceLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\Link;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ResourceLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
 
 class ResourceLinksTest extends TestCase
 {

--- a/tests/JsonApi/Schema/RelationshipTest.php
+++ b/tests/JsonApi/Schema/RelationshipTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\RelationshipLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Relationship;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
+use BahaaAlhagar\Yang\JsonApi\Schema\Relationship;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\RelationshipLinks;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 class RelationshipTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Resource/ResourceObjectTest.php
+++ b/tests/JsonApi/Schema/Resource/ResourceObjectTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Resource;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Resource;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Link\ResourceLinks;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
+use BahaaAlhagar\Yang\JsonApi\Schema\Link\ResourceLinks;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObject;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 class ResourceObjectTest extends TestCase
 {

--- a/tests/JsonApi/Schema/Resource/ResourceObjectsTest.php
+++ b/tests/JsonApi/Schema/Resource/ResourceObjectsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Schema\Resource;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Schema\Resource;
 
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\DocumentException;
-use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects;
+use BahaaAlhagar\Yang\JsonApi\Exception\DocumentException;
+use BahaaAlhagar\Yang\JsonApi\Schema\Resource\ResourceObjects;
 
 class ResourceObjectsTest extends TestCase
 {

--- a/tests/JsonApi/Serializer/JsonDeserializerTest.php
+++ b/tests/JsonApi/Serializer/JsonDeserializerTest.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Serializer;
 
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Serializer\JsonDeserializer;
-
-use function json_encode;
+use BahaaAlhagar\Yang\JsonApi\Serializer\JsonDeserializer;
 
 class JsonDeserializerTest extends TestCase
 {
@@ -32,7 +30,7 @@ class JsonDeserializerTest extends TestCase
 
     private function createResponse(array $body): Response
     {
-        $data = json_encode($body) ?: null;
+        $data = \json_encode($body) ?: null;
 
         return new Response(200, [], $data);
     }

--- a/tests/JsonApi/Serializer/JsonSerializerTest.php
+++ b/tests/JsonApi/Serializer/JsonSerializerTest.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-namespace WoohooLabs\Yang\Tests\JsonApi\Serializer;
+namespace BahaaAlhagar\Yang\Tests\JsonApi\Serializer;
 
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
-use WoohooLabs\Yang\JsonApi\Exception\SerializationException;
-use WoohooLabs\Yang\JsonApi\Serializer\JsonSerializer;
-
-use function json_encode;
+use BahaaAlhagar\Yang\JsonApi\Serializer\JsonSerializer;
+use BahaaAlhagar\Yang\JsonApi\Exception\SerializationException;
 
 class JsonSerializerTest extends TestCase
 {
@@ -31,7 +29,7 @@ class JsonSerializerTest extends TestCase
         );
 
         $this->assertSame(
-            json_encode(
+            \json_encode(
                 [
                     "data" => [
                         "type" => "a",
@@ -61,7 +59,7 @@ class JsonSerializerTest extends TestCase
         );
 
         $this->assertSame(
-            json_encode(
+            \json_encode(
                 [
                     "data" => [
                         "type" => "a",
@@ -112,8 +110,9 @@ class JsonSerializerTest extends TestCase
     private function createRequest(?array $body = null): Request
     {
         $data = null;
+
         if ($body !== null) {
-            $data = json_encode($body) ?: null;
+            $data = \json_encode($body) ?: null;
         }
 
         return new Request("GET", "", [], $data);


### PR DESCRIPTION
I was trying to use DocumentHydrator to hydrate incoming request

I found out an issue on the Hydrator relationship is not included it gets ignored

consider this example

`{
	"data": {
		"id": "",
        "type": "used_car",
		"attributes": {
			"year": 1972,
            "colour_code": "#111111",
            "gearbox": "manual",
            "transmission": "gasoline",
            "moved_kilometers": "1000",
            "selling_price": "1000",
            "price_negotiable": false,
            "seller_phone_number": "01288530263",
            "whatsapp_enabled": false,
            "address": "1000 street at gmail",
            "car_information": "some more car infromation",
            "status": "draft"
		},
		"relationships": {
			"brand": {
				"data": {
					"id": "9",
					"type": "brand"
				}
			},
			"carBodyShape": {
				"data": {
					"id": "2",
					"type": "car_body_shape"
				}
			},
			"carModel": {
				"data": {
					"id": "3",
					"type": "car_model"
				}
			},
			"carGrade": {
				"data": {
					"id": "4",
					"type": "car_model"
				}
			},
            "country": {
				"data": {
					"id": "4",
					"type": "country"
				}
			},
            "city": {
				"data": {
					"id": "4",
					"type": "city"
				}
			},
            "area": {
				"data": {
					"id": "4",
					"type": "area"
				}
			},
            "more_licenses": {
				"data": [
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28wec4e135",
						"type": "used_car_license"
					},
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb38ewc4e136",
						"type": "used_car_license"
					}
				]
			},
			"licenses": {
				"data": [
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e135",
						"type": "used_car_license"
					},
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e136",
						"type": "used_car_license"
					}
				]
			},
            "internalImages": {
				"data": [
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e135",
						"type": "used_car_image"
					},
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e136",
						"type": "used_car_image"
					}
				]
			},
            "externalImages": {
				"data": [
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e137",
						"type": "used_car_image"
					},
					{
						"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e138",
						"type": "used_car_image"
					}
				]
			}
		}
	},
	"included": [
		{
			"id": "9",
			"type": "brand",
			"attributes": {
				"title": "repellat"
			}
			
		},
		{
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e136",
			"type": "used_car_license",
			"attributes": {
				"file": 1,
				"image_type": "front"
			}
			
		},
		{
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e135",
			"type": "used_car_license",
			"attributes": {
				"file": 1,
				"image_type": "back"
			}
		},
        {
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e136",
			"type": "used_car_image",
			"attributes": {
				"file": 1,
				"image_type": "internal"
			}
			
		},
		{
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e135",
			"type": "used_car_image",
			"attributes": {
				"file": 1,
				"image_type": "internal"
			}
		},
        {
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e137",
			"type": "used_car_image",
			"attributes": {
				"file": 1,
				"image_type": "external"
			}
			
		},
		{
			"id": "bb4c1dba-3d9d-4df1-85d0-7cb28ec4e138",
			"type": "used_car_image",
			"attributes": {
				"file": 1,
				"image_type": "external"
			}
		}
	]
}`

On the last case all relationships that does not have included data gets removed from serialized to json object

This updates add an object for each not included relationship while hydrating data