### PR TITLE
Update JsonApiRequestBuilder.php, add default HTTP protocol version

### DIFF
--- a/src/JsonApi/Request/JsonApiRequestBuilder.php
+++ b/src/JsonApi/Request/JsonApiRequestBuilder.php
@@ -45,7 +45,7 @@ class JsonApiRequestBuilder
     public function initialize(): void
     {
         $this->method = "GET";
-        $this->protocolVersion = "";
+        $this->protocolVersion = "1.1";
         $this->scheme = "http";
         $this->host = "";
         $this->port = null;


### PR DESCRIPTION
Add a default to prevent misconfigured HTTP version and consequent errors like "HTTP/ is not supported by the cURL handler"